### PR TITLE
WIP compiler code loader and call expression macros

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,7 +110,7 @@
         "curly": ["error", "multi-line"],
         "dot-notation": "error",
         "eqeqeq": "error",
-        "linebreak-style": ["error", "windows"],
+        // "linebreak-style": ["error", "windows"],
         "new-parens": "error",
         "no-caller": "error",
         "no-duplicate-case": "error",

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -8,6 +8,7 @@ const del = require("del");
 const rename = require("gulp-rename");
 const concat = require("gulp-concat");
 const merge2 = require("merge2");
+const through = require("through2");
 const { src, dest, task, parallel, series, watch } = require("gulp");
 const { append, transform } = require("gulp-insert");
 const { prependFile } = require("./scripts/build/prepend");
@@ -43,8 +44,34 @@ const generateLibs = () => {
             .pipe(concat(relativeTarget, { newLine: "\n\n" }))
             .pipe(dest("built/local"))));
 };
+
 task("lib", generateLibs);
 task("lib").description = "Builds the library targets";
+
+const generateCompilerLib = () => {
+    return src("built/local/typescript.d.ts")
+            .pipe(through.obj((file, enc, cb) => {
+                const transformedFile = file.clone();
+
+                const text = transformedFile.contents.toString();
+                transformedFile.contents = Buffer.from(
+                    text
+                        .replace(/declare/g, "")
+                        .replace("namespace ts", "declare module \"compiler\" {\nnamespace ts")
+                        .replace("export = ts;", "export = ts;\n}")
+                );
+
+                // eslint-disable-next-line
+                cb(null, transformedFile);
+            }))
+            .pipe(rename("lib.compiler.d.ts"))
+            .pipe(dest("built/local/"));
+};
+
+const watchGenerateCompilerLib = () => watch("built/local/typescript.d.ts", generateCompilerLib);
+
+task("generate-compiler-lib", generateCompilerLib);
+task("watch-generate-compiler-lib", watchGenerateCompilerLib);
 
 const cleanLib = () => del(libs.map(lib => lib.target));
 cleanTasks.push(cleanLib);
@@ -236,7 +263,7 @@ task("watch-tsserver").flags = {
     "   --built": "Compile using the built version of the compiler."
 };
 
-task("min", series(preBuild, parallel(buildTsc, buildServer)));
+task("min", series(preBuild, series(parallel(buildTsc, buildServer), generateCompilerLib)));
 task("min").description = "Builds only tsc and tsserver";
 task("min").flags = {
     "   --built": "Compile using the built version of the compiler."
@@ -245,7 +272,7 @@ task("min").flags = {
 task("clean-min", series(cleanTsc, cleanServer));
 task("clean-min").description = "Cleans outputs for tsc and tsserver";
 
-task("watch-min", series(preBuild, parallel(watchLib, watchDiagnostics, watchTsc, watchServer)));
+task("watch-min", series(preBuild, parallel(watchLib, watchGenerateCompilerLib, watchDiagnostics, watchTsc, watchServer)));
 task("watch-min").description = "Watches for changes to a tsc and tsserver only";
 task("watch-min").flags = {
     "   --built": "Compile using the built version of the compiler."
@@ -409,13 +436,13 @@ const buildOtherOutputs = parallel(buildCancellationToken, buildTypingsInstaller
 task("other-outputs", series(preBuild, buildOtherOutputs));
 task("other-outputs").description = "Builds miscelaneous scripts and documents distributed with the LKG";
 
-task("local", series(preBuild, parallel(localize, buildTsc, buildServer, buildServices, buildLssl, buildOtherOutputs)));
+task("local", series(preBuild, series(parallel(localize, buildTsc, buildServer, buildServices, buildLssl, buildOtherOutputs), generateCompilerLib)));
 task("local").description = "Builds the full compiler and services";
 task("local").flags = {
     "   --built": "Compile using the built version of the compiler."
 };
 
-task("watch-local", series(preBuild, parallel(watchLib, watchDiagnostics, watchTsc, watchServices, watchServer, watchLssl)));
+task("watch-local", series(preBuild, parallel(watchLib, watchGenerateCompilerLib, watchDiagnostics, watchTsc, watchServices, watchServer, watchLssl)));
 task("watch-local").description = "Watches for changes to projects in src/ (but does not execute tests).";
 task("watch-local").flags = {
     "   --built": "Compile using the built version of the compiler."

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "typescript",
             "version": "4.9.0",
             "license": "Apache-2.0",
+            "dependencies": {
+                "pirates": "^4.0.5"
+            },
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6434,6 +6437,14 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pirates": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+            "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/plugin-error": {
@@ -13526,6 +13537,11 @@
             "requires": {
                 "pinkie": "^2.0.0"
             }
+        },
+        "pirates": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+            "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
         },
         "plugin-error": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
         "./ThirdPartyNoticeText.txt",
         "!**/.gitattributes"
     ],
+    "dependencies": {
+        "pirates": "^4.0.5"
+    },
     "devDependencies": {
         "@octokit/rest": "latest",
         "@types/async": "latest",

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -93,7 +93,8 @@ namespace ts {
         ["esnext.bigint", "lib.es2020.bigint.d.ts"],
         ["esnext.string", "lib.es2022.string.d.ts"],
         ["esnext.promise", "lib.es2021.promise.d.ts"],
-        ["esnext.weakref", "lib.es2021.weakref.d.ts"]
+        ["esnext.weakref", "lib.es2021.weakref.d.ts"],
+        ["compiler", "lib.compiler.d.ts"]
     ];
 
     /**

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1554,6 +1554,26 @@
         "category": "Error",
         "code": 1800
     },
+    "Macro functions must be named": {
+        "category": "Error",
+        "code": 1801
+    },
+    "Macro keyword is only allowed on function expressions or function declarations": {
+        "category": "Error",
+        "code": 1802
+    },
+    "Macro functions must not be async": {
+        "category": "Error",
+        "code": 1803
+    },
+    "Macros can't be used in the same file they are defined in": {
+        "category": "Error",
+        "code": 1804
+    },
+    "Macros must be invoked with the '!' operator": {
+        "category": "Error",
+        "code": 1805
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1688,6 +1688,9 @@ namespace ts {
                     case SyntaxKind.EndOfDeclarationMarker:
                     case SyntaxKind.MergeDeclarationMarker:
                         return;
+
+                    case SyntaxKind.MacroKeyword:
+                        return;
                 }
                 if (isExpression(node)) {
                     hint = EmitHint.Expression;

--- a/src/compiler/loader.ts
+++ b/src/compiler/loader.ts
@@ -1,0 +1,153 @@
+namespace ts {
+    const Pirates = require("pirates") as typeof import("pirates");
+
+    (function installRequireHook() {
+        (globalThis as any).compiler_1 = ts;
+        (globalThis as any).compiler_1.default = ts;
+
+        Pirates.addHook((code, filename) => {
+            return compileModule(code, filename);
+        }, {
+            extensions: [".ts"],
+            ignoreNodeModules: true,
+        });
+    })();
+
+    let metaProgram: Program | undefined;
+    function getMetaProgram() {
+        if(!!metaProgram) return metaProgram;
+
+        console.time("create metaprogram");
+
+        const declarations = getMacroDeclarations();
+        const sourceFileNameSet = new Set<string>();
+        for (const declaration of declarations) {
+            const sourceFile = getSourceFileOfNode(declaration);
+            sourceFileNameSet.add(sourceFile.fileName);
+        }
+        const sourceFileNames: string[] = [];
+        sourceFileNameSet.forEach((fileName) => sourceFileNames.push(fileName));
+
+        const compilerOptions: CompilerOptions = {
+            metaprogram: true,
+            target: ScriptTarget.ES5,
+            module: ModuleKind.CommonJS,
+            skipLibCheck: true,
+            declaration: false,
+            strict: true
+        };
+
+        metaProgram = createProgram({
+            rootNames: sourceFileNames,
+            options: compilerOptions
+        });
+
+        console.timeEnd("create metaprogram");
+
+        return metaProgram;
+    }
+
+    function emitSourceFile(path: string) {
+        const program = getMetaProgram();
+        const source = program.getSourceFile(path);
+
+        if(!source) {
+            throw new Error(`Could not find source file for path ${path}`);
+        }
+
+        let emitText: string | undefined;
+        const write: WriteFileCallback = (_fileName, text) => {
+            emitText = text;
+        };
+
+        // eslint-disable-next-line local/boolean-trivia
+        const metaEmit = program.emit(source, write, undefined, undefined, {
+            before: [
+                (context: TransformationContext) => (file: SourceFile) => {
+                    return visitEachChild(file, (node) => {
+                        if(isImportDeclaration(node)) {
+                            if(isCompilerModuleSpecifier(node.moduleSpecifier)) {
+                                return undefined;
+                            }
+                        }
+
+                        return node;
+                    }, context);
+                }
+            ]
+        });
+
+        if(metaEmit.diagnostics.length > 0) {
+            console.error("Meta emit diagnostics:");
+            console.error(formatDiagnostics(metaEmit.diagnostics, {
+                getCurrentDirectory: () => sys.getCurrentDirectory(),
+                getNewLine: () => sys.newLine,
+                getCanonicalFileName: createGetCanonicalFileName(sys.useCaseSensitiveFileNames),
+            }));
+        }
+
+        if(!emitText) {
+            throw new Error(`Could not emit source file for path ${path}`);
+        }
+
+        return emitText;
+    }
+
+    const moduleCache = new Map<string, any>();
+    const macroCache = new Map<MacroDeclarationNode, MacroFunction>();
+
+    function compileModule(_text: string, path: string) {
+        const text = emitSourceFile(path);
+        return text;
+    }
+
+    function loadModule(path: string) {
+        if(moduleCache.has(path)) return moduleCache.get(path);
+
+        const mod = require(path);
+        moduleCache.set(path, mod);
+
+        return mod;
+    }
+
+    export function loadMacro<T extends BaseMacroContext = BaseMacroContext>(declaration: MacroDeclarationNode): MacroFunction<T> {
+        if(macroCache.has(declaration)) return macroCache.get(declaration) as MacroFunction<T>;
+
+        const sourceFile = getSourceFileOfNode(declaration);
+        const path = sourceFile.fileName;
+
+        const mod = loadModule(path);
+
+        if(isFunctionDeclaration(declaration)) {
+            const name = hasSyntacticModifier(declaration, ModifierFlags.Default) ? "default" : declaration.name.escapedText.toString();
+            const macro = mod[name];
+
+            if(!macro) {
+                throw new Error(`Function ${declaration.name.escapedText} not found in module ${path}`);
+            }
+
+            macroCache.set(declaration, macro);
+
+            return macro;
+        }
+        else if(isFunctionExpression(declaration)) {
+            const parent = declaration.parent;
+            if(isVariableDeclaration(parent)) {
+                if(isIdentifier(parent.name)) {
+                    const name = parent.name.escapedText.toString();
+                    const macro = mod[name];
+
+                    if(!mod[name]) {
+                        throw new Error(`Function ${name} not found in module ${path}`);
+                    }
+
+                    macroCache.set(declaration, macro);
+
+                    return macro;
+                }
+            }
+        }
+
+        throw new Error(`Failed to load macro from ${path}`);
+    }
+}

--- a/src/compiler/macros.ts
+++ b/src/compiler/macros.ts
@@ -1,0 +1,201 @@
+namespace ts {
+
+    export const RuntimeValue = {
+        string: "",
+        number: 0,
+        boolean: false,
+        symbol: Symbol(),
+        object: {},
+        promise: new Promise<any>(() => {})
+    };
+
+    export type MacroDeclarationNode = Omit<FunctionDeclaration | FunctionExpression, "name"> & { name: Identifier };
+
+    export function isMacroDeclarationNode(node: Node): node is MacroDeclarationNode {
+        return (isFunctionDeclaration(node) || isFunctionExpression(node)) && !!node.name && isIdentifier(node.name) && hasSyntacticModifier(node, ModifierFlags.Macro);
+    }
+
+    export type MacroCallExpressionNode = Omit<CallExpression, "expression"> & {
+        expression: Omit<NonNullExpression, "expression"> & {expression: Identifier}
+    };
+
+    export function isMacroCallExpressionNode(node: Node): node is MacroCallExpressionNode {
+        return isCallExpression(node) && isNonNullExpression(node.expression) && isIdentifier(node.expression.expression);
+    }
+
+    export function isCompilerModuleSpecifier(node: Expression): node is StringLiteral {
+        return isStringLiteral(node) && node.text === "compiler";
+    }
+
+    export interface MacroResult {
+        kind: "replace" | "append" | "prepend" | "remove" | "appendAll" | "prependAll";
+    }
+
+    export interface MacroReplaceResult extends MacroResult {
+        kind: "replace";
+        node: Node;
+    }
+
+    export function isMacroReplaceResult(result: MacroResult): result is MacroReplaceResult {
+        return result.kind === "replace";
+    }
+
+    export interface MacroAppendResult extends MacroResult {
+        kind: "append";
+        node: Node;
+    }
+
+    export function isMAcroAppendResult(result: MacroResult): result is MacroAppendResult {
+        return result.kind === "append";
+    }
+
+    export interface MacroPrependResult extends MacroResult {
+        kind: "prepend";
+        node: Node;
+    }
+
+    export function isMacroPrependResult(result: MacroResult): result is MacroPrependResult {
+        return result.kind === "prepend";
+    }
+
+    export interface MacroRemoveResult extends MacroResult {
+        kind: "remove";
+    }
+
+    export function isMacroRemoveResult(result: MacroResult): result is MacroRemoveResult {
+        return result.kind === "remove";
+    }
+
+    export interface MacroAppendAllResult extends MacroResult {
+        kind: "appendAll";
+        node: Node;
+    }
+
+    export function isMacroAppendAllResult(result: MacroResult): result is MacroAppendAllResult {
+        return result.kind === "appendAll";
+    }
+
+    export interface MacroPrependAllResult extends MacroResult {
+        kind: "prependAll";
+        node: Node;
+    }
+
+    export function isMacroPrependAllResult(result: MacroResult): result is MacroPrependAllResult {
+        return result.kind === "prependAll";
+    }
+
+    export class MacroResults {
+        private list: MacroResult[] = [];
+
+        public static toList(results: MacroResults) {
+            return results.list;
+        }
+
+        private static replacementNode(newNode: Node, oldNode: Node) {
+            return {
+                ...newNode,
+                parent: oldNode.parent
+            };
+        }
+
+        public static toReplacement(node: Node, results: MacroResults): Node | undefined {
+            const result = MacroResults.toList(results);
+            const remove = result.some(isMacroRemoveResult);
+            if(remove) return factory.createVoidZero();
+
+            const replace = result.find(x => isMacroReplaceResult(x)) as MacroReplaceResult;
+            if(replace) {
+                return this.replacementNode(replace.node, node);
+            }
+
+            return node;
+        }
+
+        replace(node: Node) {
+            this.list.push({ kind: "replace", node } as MacroReplaceResult);
+        }
+
+        append(node: Node) {
+            this.list.push({ kind: "append", node } as MacroAppendResult);
+        }
+
+        prepend(node: Node) {
+            this.list.push({ kind: "prepend", node } as MacroPrependResult);
+        }
+
+        remove() {
+            this.list.push({ kind: "remove" } as MacroRemoveResult);
+        }
+
+        appendAll(node: Node) {
+            this.list.push({ kind: "appendAll", node } as MacroAppendAllResult);
+        }
+
+        prependAll(node: Node) {
+            this.list.push({ kind: "prependAll", node } as MacroPrependAllResult);
+        }
+    }
+
+    export function createBaseMacroContext(sourceFile: SourceFile, context: TransformationContext): BaseMacroContext {
+        return {
+            factory: context.factory,
+            sourceFile,
+            context,
+            result: new MacroResults(),
+        };
+    }
+
+    export interface BaseMacroContext {
+        readonly factory: NodeFactory;
+        readonly context: TransformationContext;
+        readonly sourceFile: SourceFile;
+        readonly result: MacroResults;
+    };
+
+    export interface CallExpressionMacroContext extends BaseMacroContext {
+        readonly node: MacroCallExpressionNode;
+    };
+
+    export type MacroFunction<T extends BaseMacroContext = BaseMacroContext> = (this: T, ...args: any[]) => void;
+
+    const macroBindings = new Map<Node, MacroDeclarationNode>();
+    const metaprogramSources = new Set<string>();
+
+    export function bindMacro(node: Node, declaration: MacroDeclarationNode) {
+        macroBindings.set(node, declaration);
+    }
+
+    export function getMacroBinding(node: Node): MacroDeclarationNode | undefined {
+        return macroBindings.get(node);
+    }
+
+    export function getMacroDeclarations(): MacroDeclarationNode[] {
+        const macros: MacroDeclarationNode[] = [];
+        macroBindings.forEach((macro) => macros.push(macro));
+        return macros;
+    }
+
+    export function addMetaprogramSourceFile(path: string) {
+        metaprogramSources.add(path);
+    }
+
+    export function getMetaprogramSourceFiles(): string[] {
+        const sourceFiles: string[] = [];
+        metaprogramSources.forEach((source) => sourceFiles.push(source));
+        return sourceFiles;
+    }
+
+    export function executeCallExpressionMacro(context: TransformationContext, node: MacroCallExpressionNode, declaration: MacroDeclarationNode): Node | undefined {
+        const macroContext: CallExpressionMacroContext = {
+            ...createBaseMacroContext(getSourceFileOfNode(node), context),
+            node
+        };
+
+        const macro = loadMacro<CallExpressionMacroContext>(declaration);
+
+        macro.apply(macroContext);
+
+        return MacroResults.toReplacement(node, macroContext.result);
+    }
+
+}

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2360,6 +2360,7 @@ namespace ts {
             return token() === SyntaxKind.ClassKeyword || token() === SyntaxKind.FunctionKeyword ||
                 token() === SyntaxKind.InterfaceKeyword ||
                 (token() === SyntaxKind.AbstractKeyword && lookAhead(nextTokenIsClassKeywordOnSameLine)) ||
+                (token() === SyntaxKind.MacroKeyword && lookAhead(nextTokenIsClassKeywordOnSameLine)) ||
                 (token() === SyntaxKind.AsyncKeyword && lookAhead(nextTokenIsFunctionKeywordOnSameLine));
         }
 
@@ -6050,6 +6051,7 @@ namespace ts {
                 case SyntaxKind.OpenBraceToken:
                     return parseObjectLiteralExpression();
                 case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.MacroKeyword:
                     // Async arrow functions are parsed earlier in parseAssignmentExpressionOrHigher.
                     // If we encounter `async [no LineTerminator here] function` then this is an async
                     // function; otherwise, its an identifier.
@@ -6196,6 +6198,7 @@ namespace ts {
             const pos = getNodePos();
             const hasJSDoc = hasPrecedingJSDocComment();
             const modifiers = parseModifiers();
+
             parseExpected(SyntaxKind.FunctionKeyword);
             const asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
             const isGenerator = asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
@@ -6659,6 +6662,7 @@ namespace ts {
                     case SyntaxKind.AbstractKeyword:
                     case SyntaxKind.AccessorKeyword:
                     case SyntaxKind.AsyncKeyword:
+                    case SyntaxKind.MacroKeyword:
                     case SyntaxKind.DeclareKeyword:
                     case SyntaxKind.PrivateKeyword:
                     case SyntaxKind.ProtectedKeyword:
@@ -6743,6 +6747,7 @@ namespace ts {
                     return isStartOfDeclaration();
 
                 case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.MacroKeyword:
                 case SyntaxKind.DeclareKeyword:
                 case SyntaxKind.InterfaceKeyword:
                 case SyntaxKind.ModuleKeyword:
@@ -6830,6 +6835,7 @@ namespace ts {
                 case SyntaxKind.AtToken:
                     return parseDeclaration();
                 case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.MacroKeyword:
                 case SyntaxKind.InterfaceKeyword:
                 case SyntaxKind.TypeKeyword:
                 case SyntaxKind.ModuleKeyword:
@@ -7409,6 +7415,7 @@ namespace ts {
                 if (modifier.kind === SyntaxKind.StaticKeyword) hasSeenStatic = true;
                 list = append(list, modifier);
             }
+
             return list && createNodeArray(list, pos);
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2360,7 +2360,7 @@ namespace ts {
             return token() === SyntaxKind.ClassKeyword || token() === SyntaxKind.FunctionKeyword ||
                 token() === SyntaxKind.InterfaceKeyword ||
                 (token() === SyntaxKind.AbstractKeyword && lookAhead(nextTokenIsClassKeywordOnSameLine)) ||
-                (token() === SyntaxKind.MacroKeyword && lookAhead(nextTokenIsClassKeywordOnSameLine)) ||
+                (token() === SyntaxKind.MacroKeyword && lookAhead(nextTokenIsFunctionKeywordOnSameLine)) ||
                 (token() === SyntaxKind.AsyncKeyword && lookAhead(nextTokenIsFunctionKeywordOnSameLine));
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7770,6 +7770,10 @@ namespace ts {
             }
             const moduleSpecifier = parseModuleSpecifier();
 
+            if(isCompilerModuleSpecifier(moduleSpecifier)) {
+                addMetaprogramSourceFile(fileName);
+            }
+
             let assertClause: AssertClause | undefined;
             if (token() === SyntaxKind.AssertKeyword && !scanner.hasPrecedingLineBreak()) {
                 assertClause = parseAssertClause();

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -159,6 +159,7 @@ namespace ts {
         with: SyntaxKind.WithKeyword,
         use: SyntaxKind.UseKeyword,
         defer: SyntaxKind.DeferKeyword,
+        macro: SyntaxKind.MacroKeyword,
         yield: SyntaxKind.YieldKeyword,
         async: SyntaxKind.AsyncKeyword,
         await: SyntaxKind.AwaitKeyword,

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -47,6 +47,7 @@ namespace ts {
 
         addRange(transformers, customTransformers && map(customTransformers.before, wrapScriptTransformerFactory));
 
+        transformers.push(transformMetaprogramReferences);
         transformers.push(transformCustomSyntax);
 
         transformers.push(transformTypeScript);

--- a/src/compiler/transformers/custom.ts
+++ b/src/compiler/transformers/custom.ts
@@ -39,6 +39,10 @@ namespace ts {
     export function transformCustomSyntax(context: TransformationContext) {
         return (sourceFile: SourceFile) => {
             const visitor = (node: Node): VisitResult<Node> => {
+                if(isFunctionDeclaration(node) && hasSyntacticModifier(node, ModifierFlags.Macro)) {
+                    console.log("macro declaration", node.name?.escapedText);
+                }
+
                 if(isFunctionBody(node)) {
                     const deferStatements = node.statements.filter(statement => isDeferStatement(statement)) as DeferStatement[];
 

--- a/src/compiler/transformers/custom.ts
+++ b/src/compiler/transformers/custom.ts
@@ -39,10 +39,6 @@ namespace ts {
     export function transformCustomSyntax(context: TransformationContext) {
         return (sourceFile: SourceFile) => {
             const visitor = (node: Node): VisitResult<Node> => {
-                if(isFunctionDeclaration(node) && hasSyntacticModifier(node, ModifierFlags.Macro)) {
-                    console.log("macro declaration", node.name?.escapedText);
-                }
-
                 if(isFunctionBody(node)) {
                     const deferStatements = node.statements.filter(statement => isDeferStatement(statement)) as DeferStatement[];
 

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -38,6 +38,9 @@
         "commandLineParser.ts",
         "moduleNameResolver.ts",
 
+        "loader.ts",
+        "macros.ts",
+
         "binder.ts",
         "symbolWalker.ts",
         "checker.ts",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -167,6 +167,7 @@ namespace ts {
         AssertKeyword,
         AnyKeyword,
         AsyncKeyword,
+        MacroKeyword,
         AwaitKeyword,
         BooleanKeyword,
         ConstructorKeyword,
@@ -561,6 +562,7 @@ namespace ts {
         | SyntaxKind.AssertsKeyword
         | SyntaxKind.AssertKeyword
         | SyntaxKind.AsyncKeyword
+        | SyntaxKind.MacroKeyword
         | SyntaxKind.AwaitKeyword
         | SyntaxKind.BigIntKeyword
         | SyntaxKind.BooleanKeyword
@@ -644,6 +646,7 @@ namespace ts {
         | SyntaxKind.AbstractKeyword
         | SyntaxKind.AccessorKeyword
         | SyntaxKind.AsyncKeyword
+        | SyntaxKind.MacroKeyword
         | SyntaxKind.ConstKeyword
         | SyntaxKind.DeclareKeyword
         | SyntaxKind.DefaultKeyword
@@ -838,6 +841,7 @@ namespace ts {
         In =                 1 << 15, // Contravariance modifier
         Out =                1 << 16, // Covariance modifier
         Decorator =          1 << 17, // Contains a decorator.
+        Macro =              1 << 18, // Represents a macro.
         HasComputedFlags =   1 << 29, // Modifier flags have been computed
 
         AccessibilityModifier = Public | Private | Protected,
@@ -1349,6 +1353,7 @@ namespace ts {
     export type AbstractKeyword = ModifierToken<SyntaxKind.AbstractKeyword>;
     export type AccessorKeyword = ModifierToken<SyntaxKind.AccessorKeyword>;
     export type AsyncKeyword = ModifierToken<SyntaxKind.AsyncKeyword>;
+    export type MacroKeyword = ModifierToken<SyntaxKind.MacroKeyword>;
     export type ConstKeyword = ModifierToken<SyntaxKind.ConstKeyword>;
     export type DeclareKeyword = ModifierToken<SyntaxKind.DeclareKeyword>;
     export type DefaultKeyword = ModifierToken<SyntaxKind.DefaultKeyword>;
@@ -1369,6 +1374,7 @@ namespace ts {
         | AbstractKeyword
         | AccessorKeyword
         | AsyncKeyword
+        | MacroKeyword
         | ConstKeyword
         | DeclareKeyword
         | DefaultKeyword

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6694,6 +6694,8 @@ namespace ts {
         /* @internal */ showConfig?: boolean;
         useDefineForClassFields?: boolean;
 
+        /* @internal */ metaprogram?: boolean;
+
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5045,6 +5045,7 @@ namespace ts {
             case SyntaxKind.ConstKeyword: return ModifierFlags.Const;
             case SyntaxKind.DefaultKeyword: return ModifierFlags.Default;
             case SyntaxKind.AsyncKeyword: return ModifierFlags.Async;
+            case SyntaxKind.MacroKeyword: return ModifierFlags.Macro;
             case SyntaxKind.ReadonlyKeyword: return ModifierFlags.Readonly;
             case SyntaxKind.OverrideKeyword: return ModifierFlags.Override;
             case SyntaxKind.InKeyword: return ModifierFlags.In;

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1223,6 +1223,7 @@ namespace ts {
             case SyntaxKind.AbstractKeyword:
             case SyntaxKind.AccessorKeyword:
             case SyntaxKind.AsyncKeyword:
+            case SyntaxKind.MacroKeyword:
             case SyntaxKind.ConstKeyword:
             case SyntaxKind.DeclareKeyword:
             case SyntaxKind.DefaultKeyword:


### PR DESCRIPTION
# Macros

Only call expression macros will be implemented in this PR `macro!()`

## TODOs
- [x] parse `macro` modifier
- [x] typecheck `macro` modifier
- [x] transpile and load code
- [x] cache transpiled output
- [x] run macro on transform

## Typecheck rules
- [x] only allow on named functions
- [x] no arrow function
- [x] no async
- [ ] check for `this` param type
- [ ] colliding macro names in same file
- [x] callsite must have `!` if it's a macro invocation
- [x] invocation can't be in the same file as definition